### PR TITLE
chore: clean GitHub Actions test output to show only relevant lines

### DIFF
--- a/.github/workflows/playwright-tests.yml
+++ b/.github/workflows/playwright-tests.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Run UI tests (prod, pretty output)
         run: |
           chmod +x ./test.sh
-          ./test.sh --select-class com.automationexercise.tests.ui.LoginUiTest    | grep -v "Playwright Host validation warning"
-          ./test.sh --select-class com.automationexercise.tests.ui.SignupUiTest   | grep -v "Playwright Host validation warning"
-          ./test.sh --select-class com.automationexercise.tests.ui.CheckoutUiTest | grep -v "Playwright Host validation warning"
+          ./test.sh --select-class com.automationexercise.tests.ui.LoginUiTest    | grep -E '===|✔|BUILD SUCCESS|BUILD FAILURE'
+          ./test.sh --select-class com.automationexercise.tests.ui.SignupUiTest   | grep -E '===|✔|BUILD SUCCESS|BUILD FAILURE'
+          ./test.sh --select-class com.automationexercise.tests.ui.CheckoutUiTest | grep -E '===|✔|BUILD SUCCESS|BUILD FAILURE'
         env:
           CI: true
         continue-on-error: true
@@ -69,8 +69,8 @@ jobs:
       - name: Run API tests (prod, pretty output)
         run: |
           chmod +x ./test.sh
-          ./test.sh --select-class com.automationexercise.tests.api.LoginApiTest    | grep -v "Playwright Host validation warning"
-          ./test.sh --select-class com.automationexercise.tests.api.UserCrudApiTest | grep -v "Playwright Host validation warning"
+          ./test.sh --select-class com.automationexercise.tests.api.LoginApiTest    | grep -E '===|✔|BUILD SUCCESS|BUILD FAILURE'
+          ./test.sh --select-class com.automationexercise.tests.api.UserCrudApiTest | grep -E '===|✔|BUILD SUCCESS|BUILD FAILURE'
         env:
           CI: true
         continue-on-error: true


### PR DESCRIPTION
Filtra la salida de los tests en GitHub Actions para mostrar solo las líneas relevantes (===, ✔, BUILD SUCCESS, BUILD FAILURE).